### PR TITLE
[#7] Fix unresolved env var templates bypassing saved credentials

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "cellartracker-mcp",
       "source": "./",
       "description": "CellarTracker wine cellar management — MCP tools + skills for inventory, drinking recommendations, and purchase evaluation.",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "author": { "name": "Brad Slavin" },
       "license": "MIT",
       "keywords": ["wine", "cellartracker", "cellar", "mcp"],

--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ Works with both **Claude Desktop** (mac app) and **Claude Code**. No prerequisit
 
 **Easiest — just ask Claude** (recommended):
 
-After installing, start a conversation and say:
+After installing, open **Claude Code** and say:
 
 > *"Set up my CellarTracker credentials"*
 
 Claude will ask for your cellartracker.com username and password, verify them, and save them securely. You're ready to go immediately — no restart needed.
+
+> **Note:** Use Claude Code for initial setup. The setup tool is not yet available in Claude Chat (desktop app conversations).
 
 **Alternative — environment variables** (for advanced users):
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cellartracker-mcp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "MCP server for CellarTracker wine cellar data — inventory, drinking recommendations, purchase history, and wishlist",
   "type": "module",
   "bin": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+/** Detect unresolved MCP client template strings like "${CT_USERNAME}". */
+function looksLikeTemplate(value: string): boolean {
+  return /^\$\{.+\}$/.test(value);
+}
+
 /** Parse key=value pairs from a .env file. Skips comments and blank lines. */
 export function loadEnvFile(filePath: string): Record<string, string> {
   const env: Record<string, string> = {};
@@ -52,7 +57,7 @@ export function getCredentials(): { username: string; password: string } {
   // Check env vars first
   const envUser = process.env.CT_USERNAME;
   const envPass = process.env.CT_PASSWORD;
-  if (envUser && envPass) {
+  if (envUser && envPass && !looksLikeTemplate(envUser) && !looksLikeTemplate(envPass)) {
     return { username: envUser, password: envPass };
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -100,7 +100,7 @@ function maturityLabel(row: Row, currentYear: number): string {
 export function createServer(): McpServer {
   const server = new McpServer({
     name: "cellartracker",
-    version: "0.2.2",
+    version: "0.2.3",
   });
 
   // --- search-cellar ---


### PR DESCRIPTION
## Summary
- Add `looksLikeTemplate()` guard in `getCredentials()` to skip env var values that are unresolved MCP client templates like `${CT_USERNAME}`
- When skipped, credential resolution falls through to the `.env` file written by `setup-credentials`
- Update README to clarify Claude Code is needed for initial setup (setup tool not yet available in Claude Chat)
- Version bump to 0.2.3

## Test Plan
- [x] Literal `${CT_USERNAME}` env vars are skipped, falls through to .env file
- [x] Real env var values still take priority
- [x] No env vars set falls through to .env file
- [x] Build compiles cleanly

Closes #7