### PR TITLE
fix: root-relative .mcpbignore paths

### DIFF
--- a/.mcpbignore
+++ b/.mcpbignore
@@ -1,24 +1,24 @@
 # Source (compiled output is in dist/)
-src/
+/src/
 tsconfig.json
 
 # Development
-.venv/
-.git/
-.github/
-.claude/
-.claude-plugin/
+/.venv/
+/.git/
+/.github/
+/.claude/
+/.claude-plugin/
 .mcp.json
 .env
 .env.example
 .mcpbignore
 
 # Skills (not supported in Desktop Extensions)
-skills/
+/skills/
 
 # Tasks and docs
-tasks/
-docs/
+/tasks/
+/docs/
 README.md
 LICENSE
 CHANGELOG.md


### PR DESCRIPTION
## Summary
- `.mcpbignore` patterns like `tasks/` matched at any depth, stripping `node_modules/@modelcontextprotocol/sdk/dist/esm/experimental/tasks/` from the `.mcpb` bundle
- This caused the Desktop Extension server to crash with `ERR_MODULE_NOT_FOUND` immediately after receiving the `initialize` message from Claude Desktop
- Fix: prefix project-level directory patterns with `/` to scope them to the repo root

## Root cause
The MCP SDK v1.27.1 has an `experimental/tasks/` directory. The `.mcpbignore` pattern `tasks/` (intended to exclude the project's `tasks/` dir) also excluded this SDK internal directory. Same issue affected `src/` (stripping `node_modules/zod/src`, `node_modules/eventsource/src`, etc.).

## Test plan
- [x] Rebuilt `.mcpb` locally — `experimental/tasks/` now included
- [x] Extracted bundle and ran `initialize` handshake — server responds correctly
- [ ] Install updated `.mcpb` in Claude Desktop and verify connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)