### PR TITLE
docs: clarify install paths for Chat, Cowork, and Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Two install methods cover different Claude Desktop modes. You may need one or bo
 | | Desktop Extension (.mcpb) | Claude Code Plugin |
 |---|---|---|
 | **Works in** | Chat, Cowork | Cowork, Code |
-| **Tools** | 8 cellar tools | All 9 tools |
+| **Tools** | 8 cellar tools | All 9 tools (includes `setup-credentials`) |
 | **Skills** | No | Yes |
 | **Setup** | One-click download | Marketplace or CLI |
 | **Credentials** | Prompted on install, stored in OS keychain | Run `setup-credentials` after install |


### PR DESCRIPTION
## Summary

- Reframes Desktop Extension and Claude Code Plugin as **complementary** install methods (not alternatives)
- Adds comparison table showing which modes each method covers
- Adds "Which do I need?" guidance for Chat-only, Code-only, Cowork, and full coverage users
- Makes credential setup an explicit, required step for the plugin path (prevents confusing errors when invoking skills without credentials)
- Updates skills note and `setup-credentials` description for accuracy

## Context

Testing revealed that Claude Desktop's three modes have distinct MCP access:
- **Chat**: Desktop Extensions (.mcpb) only — plugins don't work (web container)
- **Cowork**: Both extensions and plugins work
- **Code**: Plugins only

The previous README presented three install paths as alternatives, which was misleading.

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all install instructions are preserved from previous version
- [ ] Table accurately reflects tested behavior across modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)