### PR TITLE
[#21] Fix marketplace.json version mismatch and add to verify-versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "cellartracker-mcp",
       "source": "./",
       "description": "CellarTracker wine cellar management — MCP tools + skills for inventory, drinking recommendations, and purchase evaluation.",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "author": { "name": "Brad Slavin" },
       "license": "MIT",
       "keywords": ["wine", "cellartracker", "cellar", "mcp"],

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "pack": "mcpb pack .",
-    "verify-versions": "node --input-type=module -e \"import{readFileSync}from'node:fs';const p=JSON.parse(readFileSync('./package.json','utf8'));const m=JSON.parse(readFileSync('./manifest.json','utf8'));const pl=JSON.parse(readFileSync('./.claude-plugin/plugin.json','utf8'));if(p.version!==m.version||p.version!==pl.version){console.error('Version mismatch!',{pkg:p.version,manifest:m.version,plugin:pl.version});process.exit(1)}else{console.log('Versions in sync:',p.version)}\"",
+    "verify-versions": "node --input-type=module -e \"import{readFileSync}from'node:fs';const p=JSON.parse(readFileSync('./package.json','utf8'));const m=JSON.parse(readFileSync('./manifest.json','utf8'));const pl=JSON.parse(readFileSync('./.claude-plugin/plugin.json','utf8'));const mp=JSON.parse(readFileSync('./.claude-plugin/marketplace.json','utf8'));const mpv=mp.plugins[0].version;if(p.version!==m.version||p.version!==pl.version||p.version!==mpv){console.error('Version mismatch!',{pkg:p.version,manifest:m.version,plugin:pl.version,marketplace:mpv});process.exit(1)}else{console.log('Versions in sync:',p.version)}\"",
     "prepublishOnly": "npm run verify-versions && npm run build"
   },
   "keywords": [


### PR DESCRIPTION
## Summary
- Bump `marketplace.json` version from `0.2.5` to `0.2.6` to match the other 3 version sources
- Add `marketplace.json` as the 4th file checked by the `verify-versions` script (accounts for nested `plugins[0].version` structure)

## Test Plan
- [x] `npm run verify-versions` reports "Versions in sync: 0.2.6"
- [x] `npm test` — all 44 tests pass

Closes #21