### PR TITLE
[#20] Harden credential input validation in setup-credentials

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -86,6 +86,12 @@ describe("loadEnvFile", () => {
     const env = loadEnvFile(envPath);
     expect(env).toEqual({ KEY: "value" });
   });
+
+  it("unescapes backslash-escaped double quotes inside quoted values", () => {
+    fs.writeFileSync(envPath, 'KEY="pass\\"word"\n');
+    const env = loadEnvFile(envPath);
+    expect(env.KEY).toBe('pass"word');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,7 +32,7 @@ export function loadEnvFile(filePath: string): Record<string, string> {
       value[0] === value[value.length - 1] &&
       (value[0] === '"' || value[0] === "'")
     ) {
-      value = value.slice(1, -1);
+      value = value.slice(1, -1).replace(/\\"/g, '"');
     }
     env[key] = value;
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -629,12 +629,24 @@ export function createServer(): McpServer {
         }
 
         // Reject values that would corrupt the .env file
-        if (/[\r\n]/.test(username) || /[\r\n]/.test(password)) {
+        if (/[\r\n\0]/.test(username) || /[\r\n\0]/.test(password)) {
           return {
             content: [
               {
                 type: "text" as const,
-                text: "Username and password must not contain newline characters.",
+                text: "Credentials must not contain newline or null characters.",
+              },
+            ],
+          };
+        }
+
+        // Length limit
+        if (username.length > 256 || password.length > 256) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: "Credentials must be 256 characters or fewer.",
               },
             ],
           };
@@ -647,8 +659,11 @@ export function createServer(): McpServer {
           fs.chmodSync(configDir, 0o700);
         }
 
+        // Escape embedded double quotes and write quoted values
+        const safeUser = username.replace(/"/g, '\\"');
+        const safePass = password.replace(/"/g, '\\"');
         const envPath = `${configDir}/.env`;
-        fs.writeFileSync(envPath, `CT_USERNAME=${username}\nCT_PASSWORD=${password}\n`, "utf-8");
+        fs.writeFileSync(envPath, `CT_USERNAME="${safeUser}"\nCT_PASSWORD="${safePass}"\n`, "utf-8");
         if (process.platform !== "win32") {
           fs.chmodSync(envPath, 0o600);
         }


### PR DESCRIPTION
## Summary
- Reject null bytes (`\0`) in addition to newlines in credential values
- Add 256-character length limit for username and password
- Quote values when writing `.env` file and escape embedded double quotes
- Update `loadEnvFile` to unescape `\"` inside quoted values (with test)

## Test Plan
- [x] `npm run build` — compiles cleanly
- [x] `npm test` — all 45 tests pass (1 new test for escaped quote parsing)
- [ ] Manual: `setup-credentials` with normal credentials still works
- [ ] Manual: credentials containing `=` still parse correctly

Closes #20