### PR TITLE
[#29] Fix incomplete escape/unescape parity in .env write/read

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -92,6 +92,25 @@ describe("loadEnvFile", () => {
     const env = loadEnvFile(envPath);
     expect(env.KEY).toBe('pass"word');
   });
+
+  it("does not unescape backslash-quote in single-quoted values", () => {
+    fs.writeFileSync(envPath, "KEY='pass\\\"word'\n");
+    const env = loadEnvFile(envPath);
+    expect(env.KEY).toBe('pass\\"word');
+  });
+
+  it("unescapes escaped backslashes in double-quoted values", () => {
+    fs.writeFileSync(envPath, 'KEY="pass\\\\word"\n');
+    const env = loadEnvFile(envPath);
+    expect(env.KEY).toBe("pass\\word");
+  });
+
+  it("round-trips backslash-quote through escape/unescape", () => {
+    // Simulates what setup-credentials writes for a password containing \"
+    fs.writeFileSync(envPath, 'KEY="pass\\\\\\"word"\n');
+    const env = loadEnvFile(envPath);
+    expect(env.KEY).toBe('pass\\"word');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,7 +32,11 @@ export function loadEnvFile(filePath: string): Record<string, string> {
       value[0] === value[value.length - 1] &&
       (value[0] === '"' || value[0] === "'")
     ) {
-      value = value.slice(1, -1).replace(/\\"/g, '"');
+      const quote = value[0];
+      value = value.slice(1, -1);
+      if (quote === '"') {
+        value = value.replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+      }
     }
     env[key] = value;
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -659,9 +659,9 @@ export function createServer(): McpServer {
           fs.chmodSync(configDir, 0o700);
         }
 
-        // Escape embedded double quotes and write quoted values
-        const safeUser = username.replace(/"/g, '\\"');
-        const safePass = password.replace(/"/g, '\\"');
+        // Escape backslashes then double quotes for quoted .env values
+        const safeUser = username.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+        const safePass = password.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
         const envPath = `${configDir}/.env`;
         fs.writeFileSync(envPath, `CT_USERNAME="${safeUser}"\nCT_PASSWORD="${safePass}"\n`, "utf-8");
         if (process.platform !== "win32") {


### PR DESCRIPTION
## Summary
- Scope `\"` unescaping in `loadEnvFile` to double-quoted values only (single-quoted values are left untouched)
- Escape `\` → `\\` on write before escaping `"` → `\"` in setup-credentials
- Unescape `\\` → `\` on read after unescaping `\"` → `"` in loadEnvFile
- Add 3 new tests: single-quote preservation, backslash round-trip, backslash-quote round-trip

## Test Plan
- [x] `npm run build` — compiles cleanly
- [x] `npm test` — all 48 tests pass (3 new)

Closes #29