### PR TITLE
[#17] Add Security & credentials section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,30 @@ CellarTracker has no official API. This server uses their CSV export endpoint, w
 
 The server can only access **your** data — inventory, purchases, notes, and wishlist. It cannot search CellarTracker's full wine database.
 
+## Security & credentials
+
+### CellarTracker API limitations
+
+CellarTracker has no OAuth, API keys, or scoped tokens. Authentication requires your actual account username and password, sent as URL query parameters over HTTPS. While encrypted on the wire, query parameters are routinely logged in server-side access logs on CellarTracker's infrastructure. There is no way to create read-only or limited-access credentials — this MCP only performs read operations, but it authenticates with your full account.
+
+### How this server protects your credentials
+
+| Protection | Details |
+|---|---|
+| **File permissions** | Config directory `0700`, `.env` file `0600` — only your OS user can read |
+| **Error stripping** | Network errors are caught and re-thrown without the URL, which contains credentials |
+| **No logging** | Credentials never appear in stdout, stderr, or error messages |
+| **OS keychain** | Desktop Extension (`.mcpb`) stores credentials in macOS Keychain / Windows Credential Manager |
+| **Env var support** | Set `CT_USERNAME` / `CT_PASSWORD` environment variables to avoid storing credentials on disk |
+
+The Claude Code plugin stores credentials as plaintext in `~/.config/cellartracker-mcp/.env`. We evaluated OS keychain integration ([#22](https://github.com/slavins-co/cellartracker-mcp/issues/22)) and decided against it — the native dependency cost (`node-gyp` / `keytar`) outweighs the security benefit for wine cellar data, and the Desktop Extension path already uses the OS keychain.
+
+### Recommendations
+
+- **Use a unique password** for CellarTracker — do not reuse a password from other services.
+- **Prefer environment variables** over the `setup-credentials` tool if you want to avoid persisting credentials to disk.
+- **Pin to a specific version** in your MCP config (e.g., `cellartracker-mcp@0.2.6`) rather than relying on `@latest`.
+
 ## Development
 
 For contributors or anyone who wants to run from source:


### PR DESCRIPTION
## Summary
- Adds a new "Security & credentials" section to README between "How it works" and "Development"
- Discloses CellarTracker API limitations: no OAuth, credentials as URL query params, no permission scoping
- Documents credential protections: file permissions, error stripping, no logging, OS keychain (Desktop Extension), env var support
- Explains the decision from #22 not to add keychain integration for the plugin path, with link to the issue
- Provides user recommendations: unique password, env vars, version pinning

## Test Plan
- [ ] Verify section renders correctly on GitHub
- [ ] Verify section appears between "How it works" and "Development"
- [ ] Verify all links resolve (#22 issue link)
- [ ] `npm test` passes (48/48 tests)

Closes #17