### PR TITLE
fix: add diagnostic detail to credential-not-found errors

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -173,6 +173,49 @@ describe("getCredentials", () => {
     expect(() => getCredentials()).toThrow("CellarTracker credentials not found");
   });
 
+  it("includes diagnostic detail in error when no credentials found", () => {
+    // No env vars set, no .env files
+    try {
+      getCredentials();
+      expect.fail("should have thrown");
+    } catch (e: unknown) {
+      const msg = (e as Error).message;
+      // Should report env var status
+      expect(msg).toContain("CT_USERNAME/CT_PASSWORD env vars: not set");
+      // Should report CWD path checked
+      expect(msg).toContain(tmpDir);
+      // Should report config dir path checked
+      expect(msg).toContain("~/.config/cellartracker-mcp/.env");
+      // Should mention setup-credentials
+      expect(msg).toContain("setup-credentials");
+    }
+  });
+
+  it("reports template strings in diagnostic error", () => {
+    process.env.CT_USERNAME = "${CT_USERNAME}";
+    process.env.CT_PASSWORD = "${CT_PASSWORD}";
+    // No .env files to fall back to
+    try {
+      getCredentials();
+      expect.fail("should have thrown");
+    } catch (e: unknown) {
+      const msg = (e as Error).message;
+      expect(msg).toContain("skipped (unresolved template)");
+    }
+  });
+
+  it("reports missing keys in diagnostic error when .env exists but lacks credentials", () => {
+    // Write a .env file in CWD with wrong keys
+    fs.writeFileSync(path.join(tmpDir, ".env"), "SOME_OTHER_KEY=value\n");
+    try {
+      getCredentials();
+      expect.fail("should have thrown");
+    } catch (e: unknown) {
+      const msg = (e as Error).message;
+      expect(msg).toContain("found, missing CT_USERNAME/CT_PASSWORD");
+    }
+  });
+
   it("reads from CWD .env file", () => {
     const cwdEnvPath = path.join(tmpDir, ".env");
     fs.writeFileSync(cwdEnvPath, "CT_USERNAME=cwduser\nCT_PASSWORD=cwdpass\n");

--- a/src/config.ts
+++ b/src/config.ts
@@ -61,15 +61,18 @@ export function getCredentials(): { username: string; password: string } {
   // Check env vars first
   const envUser = process.env.CT_USERNAME;
   const envPass = process.env.CT_PASSWORD;
-  if (envUser && envPass && !looksLikeTemplate(envUser) && !looksLikeTemplate(envPass)) {
+  const envIsTemplate =
+    (envUser && looksLikeTemplate(envUser)) || (envPass && looksLikeTemplate(envPass));
+
+  if (envUser && envPass && !envIsTemplate) {
     return { username: envUser, password: envPass };
   }
 
   // Try .env files in order
-  const envPaths = [
-    path.join(process.cwd(), ".env"),
-    path.join(getConfigDir(), ".env"),
-  ];
+  const cwdEnvPath = path.join(process.cwd(), ".env");
+  const configEnvPath = path.join(getConfigDir(), ".env");
+  const envPaths = [cwdEnvPath, configEnvPath];
+  const fileStatus: string[] = [];
 
   for (const envPath of envPaths) {
     const env = loadEnvFile(envPath);
@@ -92,14 +95,32 @@ export function getCredentials(): { username: string; password: string } {
       }
       return { username, password };
     }
+
+    // Track why this file didn't work (for error message)
+    const label = envPath === configEnvPath ? "~/.config/cellartracker-mcp/.env" : envPath;
+    if (!fs.existsSync(envPath)) {
+      fileStatus.push(`  - ${label}: not found`);
+    } else {
+      fileStatus.push(`  - ${label}: found, missing CT_USERNAME/CT_PASSWORD`);
+    }
+  }
+
+  // Build diagnostic error message
+  let envStatus: string;
+  if (!envUser && !envPass) {
+    envStatus = "not set";
+  } else if (envIsTemplate) {
+    envStatus = "skipped (unresolved template)";
+  } else {
+    envStatus = "incomplete (need both CT_USERNAME and CT_PASSWORD)";
   }
 
   throw new Error(
     "CellarTracker credentials not found.\n\n" +
-      "Use the setup-credentials tool to configure your login, or set CT_USERNAME and CT_PASSWORD via:\n" +
-      "  - Environment variables\n" +
-      "  - .env file in current directory\n" +
-      "  - ~/.config/cellartracker-mcp/.env"
+      "Checked:\n" +
+      `  - CT_USERNAME/CT_PASSWORD env vars: ${envStatus}\n` +
+      fileStatus.join("\n") + "\n\n" +
+      "Run the setup-credentials tool to save your login."
   );
 }
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -15,3 +15,4 @@
 - [x] #34 — Fix: validate credentials before sending to CellarTracker (PR #37)
 - [x] #35 — Fix: cellar-stats aggregate counts bottles by Quantity (PR #37)
 - [x] #36 — Fix: server.ts reads version from package.json dynamically (PR #37)
+- [x] Add diagnostic detail to credential-not-found errors (PR #38)


### PR DESCRIPTION
## Summary
- When `getCredentials()` fails, the error now reports exactly what was checked: env var status (not set / unresolved template / incomplete), and each `.env` file path with its status (not found / missing keys)
- Includes `process.cwd()` path so users can see which directory was searched
- Helps self-diagnose credential persistence issues across sessions without needing to inspect the MCP server internals

## Test plan
- [x] 3 new tests covering diagnostic detail: no env vars, template strings, missing keys in existing file
- [x] Full test suite passes (138/138)
- [x] TypeScript compiles cleanly