### PR TITLE
[#40, #42] Build staleness fix: prepare script, dist rebuild, version surfacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ cp .env.example .env
 claude --plugin-dir .
 ```
 
+### npx local-resolution footgun
+
+If you run `npx -y cellartracker-mcp` (e.g. via an MCP client config) with your working directory inside a local checkout of this repo, npm can resolve the bare package name to that local folder instead of downloading it from the registry — so whatever is on disk in `dist/` gets served, not the published version. `npm install`/`npm ci` now runs a `prepare` script that rebuilds `dist/` automatically, so a fresh clone is always current. But if you edit `src/` directly and don't run `npm install` or `npm run build` again, `dist/` will silently go stale — the server keeps running the old compiled code with no error. If output looks wrong while developing, rebuild (`npm run build`) before assuming the bug is in `src/`.
+
 ## AI Disclosure
 
 This project was developed with AI assistance.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cellartracker-mcp",
-  "version": "0.2.6",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cellartracker-mcp",
-      "version": "0.2.6",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "test": "vitest run --dir src",
     "build": "tsc",
+    "prepare": "npm run build",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "pack": "mcpb pack .",

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -16,4 +16,17 @@ describe("server version", () => {
     const hardcodedVersion = /version:\s*"[\d.]+"/;
     expect(serverSrc).not.toMatch(hardcodedVersion);
   });
+
+  it("includes the server version in refresh-data output", () => {
+    const serverSrc = fs.readFileSync(
+      path.resolve(__dirname, "../server.ts"),
+      "utf-8"
+    );
+    const refreshDataBlock = serverSrc.slice(
+      serverSrc.indexOf('"refresh-data"'),
+      serverSrc.indexOf('"setup-credentials"')
+    );
+    // Must dynamically interpolate the version constant, not a hardcoded string
+    expect(refreshDataBlock).toMatch(/Server: cellartracker-mcp v\$\{version\}/);
+  });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -580,6 +580,7 @@ export function createServer(): McpServer {
         const desc = TABLES[tableName].desc;
         lines.push(`  ${tableName.padEnd(15)} ${String(rows.length).padStart(6)} rows  (${desc})`);
       }
+      lines.push("", `Server: cellartracker-mcp v${version}`);
 
       return { content: [{ type: "text", text: lines.join("\n") }] };
     }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -41,3 +41,6 @@
 
 ## Synology Drive Sync Causes Spurious Mode-Only Git Diffs
 - Working inside a Synology Drive–synced folder, files can repeatedly show as modified in `git status` with a 644→755 mode-only diff (zero content change) — the sync client appears to re-touch permission bits independently of any edits, and it recurs even after stashing/discarding. `git config core.fileMode false` in the repo stops git from tracking permission bits and ends the noise. Verify via `git diff --raw` (look for `0000000` new-blob placeholders with identical old/new content) before assuming any "modified" file in this repo actually changed.
+
+## server.test.ts Has No Live Tool-Invocation Infrastructure
+- `src/__tests__/server.test.ts` tests `server.ts` entirely via static source-text assertions (`fs.readFileSync` + regex/substring checks on the source) — there is no `vi.mock`, no `createServer()` invocation, no mocked `getCredentials`/`exportAll` anywhere in the test suite. When adding a small, single-call-site feature to a tool handler, match this convention (a source-text assertion) rather than building new live-invocation mocking infrastructure — that's a much bigger, precedent-setting change than a one-line feature warrants. Building real tool-invocation tests would be a deliberate, separate decision, not something to introduce incidentally. (PR #55, issue #42)

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -32,3 +32,12 @@
 
 ## Falsy Zero Trap in parseInt Fallbacks
 - `parseInt(value, 10) || 1` silently converts `0` to `1` because `0` is falsy. When counting quantities, use `|| 0` to match the pattern used elsewhere (e.g., `cellar-stats` headline total). The `|| 1` pattern is only safe when you know zero is never a valid value. This caused `aggregate()` breakdown counts to exceed headline totals for cellars with consumed wines (Quantity=0). (PR #37)
+
+## Build Staleness via npx Local Resolution
+- `npx -y cellartracker-mcp` can resolve to a local checkout of this repo instead of the npm registry when the session cwd is inside it (npm's `package-lock.json` records a relative `resolved` path when this happens). If the local `dist/` wasn't rebuilt after a `src/` change, the stale compiled code silently serves — this caused the #35/#37 fix to sit unbuilt for ~4 months. Fix: a `"prepare": "npm run build"` script in `package.json` rebuilds `dist/` on every install path (fresh clone, `npm ci`, and npm's local/file-style resolution), but does NOT catch the case of editing `src/` directly without reinstalling/rebuilding — that's a manual-discipline gap with no automatic trigger point (`npm run build` before trusting local output). (PR #55, issue #40)
+
+## Lockfile Version Can Drift Independently
+- `package-lock.json`'s top-level `version` field can go stale relative to `package.json` even when nothing else in the lockfile needs updating — `npm install` doesn't always rewrite it. The existing `verify-versions` script only checks `package.json`/`manifest.json`/`plugin.json`/`marketplace.json`, not `package-lock.json`. Caught by chance while rebuilding `dist/` for #40 (0.2.6 vs 0.3.1). Worth checking `package-lock.json`'s version alongside the others if this becomes a recurring issue. (PR #55)
+
+## Synology Drive Sync Causes Spurious Mode-Only Git Diffs
+- Working inside a Synology Drive–synced folder, files can repeatedly show as modified in `git status` with a 644→755 mode-only diff (zero content change) — the sync client appears to re-touch permission bits independently of any edits, and it recurs even after stashing/discarding. `git config core.fileMode false` in the repo stops git from tracking permission bits and ends the noise. Verify via `git diff --raw` (look for `0000000` new-blob placeholders with identical old/new content) before assuming any "modified" file in this repo actually changed.

--- a/tasks/plans/2026-07-11-issue-40-plan.md
+++ b/tasks/plans/2026-07-11-issue-40-plan.md
@@ -1,0 +1,37 @@
+# Build Staleness Fix (Issue #40) Implementation Plan
+
+**Goal:** Ensure every install path (fresh clone, npx local-folder resolution) produces a `dist/` that matches current `src/`, and document the npx local-resolution footgun.
+
+**Architecture:** Add an npm `prepare` lifecycle script that runs `npm run build` automatically on `npm install`/`npm ci` (and on npx's local-install path). Rebuild `dist/` once locally to clear the existing staleness. Document the footgun in the README's Development section. No app logic changes — config + docs only, so no unit tests apply; verification is running the actual commands and reading output.
+
+Optional item (extend `verify-versions` to check dist/src staleness) — **declined by user**: `prepublishOnly` already force-rebuilds right after `verify-versions` runs, so wiring it there would never catch anything; no other automatic trigger point exists. Out of scope for this PR.
+
+---
+
+## 1. Files
+
+- Modify: `package.json` — add `"prepare": "npm run build"` to `scripts`.
+- Modify: `README.md` — add a paragraph to the existing `## Development` section explaining the npx local-resolution footgun and that `npm install` now auto-rebuilds via `prepare`.
+- Action (not a file diff): run `npm run build` locally to rebuild the stale `dist/` (gitignored, not committed).
+
+## 2. Tasks
+
+### Task 1: Add `prepare` script
+- [ ] Edit `package.json` scripts block to add `"prepare": "npm run build"` (placed after `"build"` for readability).
+- [ ] Verify: `npm install` (no args, in repo root) → Run: `npm install && ls -la dist/*.js` → Expected: build re-runs (visible `tsc` output or updated dist mtimes) and `dist/*.js` mtimes are now newer than `src/*.ts`.
+- [ ] Commit: `git add package.json && git commit -m "fix: add prepare script to rebuild dist on every install path"`
+
+### Task 2: Rebuild stale dist/ locally
+- [ ] Run: `npm run build` → Expected: exits 0, `dist/*.js` mtimes now current.
+- [ ] Verify AC: `dist/query.js` and `dist/server.js` reflect current `src/` (spot check: grep for the Quantity-based counting fix from #35/#37 in `dist/query.js`).
+- [ ] No commit — `dist/` is gitignored.
+
+### Task 3: Document the footgun in README
+- [ ] Edit `README.md` `## Development` section — add explanation: running `npx -y cellartracker-mcp` with a cwd inside a local checkout of this repo can resolve to the local folder instead of the published npm package, serving whatever `dist/` happens to be on disk; `npm install` (and therefore the `prepare` script) keeps that `dist/` current, but editing `src/` directly without reinstalling/rebuilding will still go stale.
+- [ ] Verify: `grep -n "npx" README.md` shows the new paragraph in the Development section.
+- [ ] Commit: `git add README.md && git commit -m "docs: document npx local-resolution build-staleness footgun"`
+
+## 3. Acceptance criteria check (manual, end of Phase 6)
+- [ ] Fresh clone + `npm install` produces current `dist/` — verified by Task 1's install run.
+- [ ] `npx -y cellartracker-mcp` served code is current — can't fully simulate the exact registry-vs-local resolution bug from a single repo checkout; verified indirectly via `dist/` freshness (Task 2) since that's the actual variable that determines served behavior once resolution lands on the local folder.
+- [ ] README explains the footgun — Task 3.

--- a/tasks/plans/2026-07-11-issue-42-plan.md
+++ b/tasks/plans/2026-07-11-issue-42-plan.md
@@ -1,0 +1,46 @@
+# Surface Server Version in refresh-data Output (Issue #42) Implementation Plan
+
+**Goal:** Make the running server version visible in `refresh-data` tool output, so a stale-build defect (like #40) would be immediately visible to a user instead of silently persisting for months.
+
+**Architecture:** `src/server.ts` already loads `version` from `package.json` via `createRequire` at module scope (line 102) and it's already in closure scope inside `createServer()`. Append one line to the `refresh-data` handler's `lines` array using that existing `version` constant — no new imports, no new state.
+
+Optional item (version in `getFreshPaths()` failure error messages, 7 call sites, none currently wrapped in try/catch) — **declined by user**: would require adding try/catch to 7 untouched call sites across the file, a much larger and more invasive change than the stated ACs call for. Out of scope for this addition.
+
+---
+
+## 1. Files
+
+- Modify: `src/server.ts` — add one line to the `refresh-data` tool's `lines` array (around line 576-580).
+- Modify: `src/__tests__/server.test.ts` — add one test, following this file's existing static-source-assertion convention (matches how the sibling "reads version from package.json, not a hardcoded string" test already works — this codebase has no live tool-invocation test infrastructure anywhere, so a new pure-function extraction for one interpolated line would be a new pattern for no benefit here).
+
+## 2. Tasks
+
+### Task 1: Failing test first
+- [ ] Add to `src/__tests__/server.test.ts`, same `describe("server version", …)` block:
+  ```ts
+  it("includes the server version in refresh-data output", () => {
+    const serverSrc = fs.readFileSync(
+      path.resolve(__dirname, "../server.ts"),
+      "utf-8"
+    );
+    const refreshDataBlock = serverSrc.slice(
+      serverSrc.indexOf('"refresh-data"'),
+      serverSrc.indexOf('"setup-credentials"')
+    );
+    // Must dynamically interpolate the version constant, not a hardcoded string
+    expect(refreshDataBlock).toMatch(/Server: cellartracker-mcp v\$\{version\}/);
+  });
+  ```
+- [ ] Run: `npm test` → Expected: FAIL — new test fails because `refresh-data`'s output doesn't contain that line yet.
+
+### Task 2: Minimal implementation
+- [ ] In `src/server.ts`, in the `refresh-data` handler, after the existing `lines.push` loop over table rows, add:
+  ```ts
+  lines.push("", `Server: cellartracker-mcp v${version}`);
+  ```
+- [ ] Run: `npm test` → Expected: PASS — all tests including the new one.
+- [ ] Commit: `git add src/server.ts src/__tests__/server.test.ts && git commit -m "feat: surface server version in refresh-data output"`
+
+## 3. Acceptance criteria check
+- [ ] `refresh-data` output includes the running version string — Task 2.
+- [ ] A test asserts the version line matches package.json — Task 1 (asserts dynamic interpolation of the same `version` constant already sourced from package.json, consistent with this file's existing test convention).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -17,3 +17,4 @@
 - [x] #36 — Fix: server.ts reads version from package.json dynamically (PR #37)
 - [x] Add diagnostic detail to credential-not-found errors (PR #38)
 - [x] #40 — Build staleness: add npm prepare script and rebuild dist (PR #55)
+- [x] #42 — Surface server version in refresh-data output (PR #55)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -16,3 +16,4 @@
 - [x] #35 — Fix: cellar-stats aggregate counts bottles by Quantity (PR #37)
 - [x] #36 — Fix: server.ts reads version from package.json dynamically (PR #37)
 - [x] Add diagnostic detail to credential-not-found errors (PR #38)
+- [x] #40 — Build staleness: add npm prepare script and rebuild dist (PR #55)


### PR DESCRIPTION
## Summary

**#40 — Build staleness: add npm prepare script and rebuild dist**
- Add `"prepare": "npm run build"` to `package.json` so `dist/` rebuilds automatically on every install path (fresh clone, `npm ci`, and the local/file-style resolution npx uses when cwd is inside a checkout of this repo) — closing the ~4-month staleness gap that caused `cellar-stats group_by=color` to serve pre-#35/#37 code.
- Rebuild `dist/` locally and sync `package-lock.json`'s version field (0.2.6 → 0.3.1), which had also drifted out of sync with `package.json`.
- Document the npx local-resolution footgun in the README's Development section, including the residual risk (editing `src/` without reinstalling/rebuilding still goes stale silently).
- Declined the issue's optional item (extending `verify-versions` to check dist/src staleness) — `prepublishOnly` already force-rebuilds immediately after `verify-versions` runs, so wiring the check there would never catch anything.

**#42 — Surface server version in refresh-data output**
- `refresh-data` output now appends `Server: cellartracker-mcp v<version>`, using the `version` constant `server.ts` already sources from `package.json`. Mitigates the staleness class of bug from #40 by making the running version visible to users.
- Declined the issue's "consider" item (adding version to error messages from the 7 `getFreshPaths()` call sites) — none of those currently catch errors at all, so wiring this in would mean adding try/catch to 7 untouched call sites, a much larger change than the stated ACs.

## Test plan
- [x] `npm test` — 74/74 passing
- [x] `npm install` confirmed to trigger the new `prepare` script and rebuild `dist/` with current `src/` content (spot-checked the `|| 0` fix from #35/#37 landed in the fresh `dist/query.js`)
- [x] New test asserts `refresh-data`'s output dynamically interpolates the version constant (not hardcoded), matching this file's existing test convention
- [x] Manual, live verification of the npx local-resolution path (2026-07-11): confirmed the active npx cache entry for `cellartracker-mcp` resolves via a `file:` link that symlinks `node_modules/cellartracker-mcp` directly to this repo checkout (not a copy) — so served code and repo `dist/` are always the same file, no separate stale artifact is possible. Then confirmed the fix mechanism directly: `touch src/server.ts` (simulating an unrebuilt edit) followed by `npx -y cellartracker-mcp` caused `dist/server.js` to rebuild automatically within seconds, with no manual `npm install`/`npm run build`. This is a stronger guarantee than the AC's literal `cellar-stats` sums check (which only verifies one already-fixed bug) — it verifies the general staleness-prevention mechanism the fix relies on.

## Review
- Code review (high) and security review completed pre-PR for both issues — clean, no fixes needed.

Closes #40
Closes #42